### PR TITLE
Feature/delete event frontend

### DIFF
--- a/frontend/.idea/inspectionProfiles/Project_Default.xml
+++ b/frontend/.idea/inspectionProfiles/Project_Default.xml
@@ -3,30 +3,39 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.intersoft.groupup_app
 
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -134,8 +135,8 @@ class MainActivity : ComponentActivity() {
                         ) { backStackEntry ->
                             EventDetailsPage(
                                 onGetEventFail = {
-                                    Toast.makeText(applicationContext, "Event not found", Toast.LENGTH_SHORT).show()
-                                    navController.navigate("home")
+                                    //Toast.makeText(applicationContext, "Event not found", Toast.LENGTH_SHORT).show()
+                                    //navController.navigate("home")
                                 },
                                 eventId = backStackEntry.arguments?.getInt("eventId") ?: 0,
                                 onEditEventButtonPressed = {eventId,
@@ -158,9 +159,15 @@ class MainActivity : ComponentActivity() {
                                     tempLocation = location
                                     tempHostId = hostId
 
-                                    navController.navigate("editEvent",)
+                                    navController.navigate("editEvent")
                                 },
-                                onEventDeleted = {navController.navigate("goBack")}
+                                onEventDeleted = {
+                                    val destination = navController.previousBackStackEntry!!.destination.route!!
+                                    Log.d("Navigation control", "destination is $destination")
+                                    navController.navigate("goBack")
+                                    navController.navigate("goBack")
+                                    navController.navigate(destination)
+                                }
                             )
 
                         }

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
@@ -135,8 +135,8 @@ class MainActivity : ComponentActivity() {
                         ) { backStackEntry ->
                             EventDetailsPage(
                                 onGetEventFail = {
-                                    //Toast.makeText(applicationContext, "Event not found", Toast.LENGTH_SHORT).show()
-                                    //navController.navigate("home")
+                                    Toast.makeText(applicationContext, "Event not found", Toast.LENGTH_SHORT).show()
+                                    navController.navigate("home")
                                 },
                                 eventId = backStackEntry.arguments?.getInt("eventId") ?: 0,
                                 onEditEventButtonPressed = {eventId,

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/MainActivity.kt
@@ -159,7 +159,8 @@ class MainActivity : ComponentActivity() {
                                     tempHostId = hostId
 
                                     navController.navigate("editEvent",)
-                                }
+                                },
+                                onEventDeleted = {navController.navigate("goBack")}
                             )
 
                         }

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -19,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.intersoft.auth.AuthContext
 import com.intersoft.event.EventManager
@@ -28,6 +31,7 @@ import com.intersoft.ui.LabelText
 import com.intersoft.ui.LoadingScreen
 import com.intersoft.ui.ParticipantNumberDisplayField
 import com.intersoft.ui.PrimaryButton
+import com.intersoft.ui.R
 import com.intersoft.ui.TitleText
 import com.intersoft.utils.DateTimeManager
 
@@ -87,6 +91,10 @@ fun EventDetailsPage(
     }
 
     var isShowingLeaveConfirmationDialog by remember{
+        mutableStateOf(false)
+    }
+
+    var isShowingDeleteDialog by remember{
         mutableStateOf(false)
     }
 
@@ -181,7 +189,7 @@ fun EventDetailsPage(
 
                 hostId == AuthContext.id -> {
                     EventDetailsButton(buttonName = "Delete Event") {
-                        EventManager.deleteEvent(eventId, {eventName = "SUCCESS"}, {eventName = "FAIL"})
+                        isShowingDeleteDialog = true
                     }
                     Spacer(modifier = Modifier.height(20.dp))
                     EventDetailsButton(buttonName = "Edit Event") {
@@ -217,6 +225,26 @@ fun EventDetailsPage(
                 isShowingLeaveConfirmationDialog = false
             }
 
+        )
+    }
+
+    if(isShowingDeleteDialog){
+        ConfirmationDialog(
+            title = "Deleting event",
+            dialogText = "Are you sure you want to delete the event \"${eventName}\"?",
+            onConfirmButton = {
+                EventManager.deleteEvent(eventId, {eventName = "SUCCESS"}, {eventName = it})
+                isShowingDeleteDialog = false
+            },
+            onDismissButton = {
+                isShowingDeleteDialog = false
+            },
+            ButtonDefaults.buttonColors(
+                containerColor = colorResource(R.color.inputField),
+                contentColor = colorResource(R.color.errorColor),
+                disabledContainerColor = colorResource(R.color.secondary),
+                disabledContentColor = colorResource(R.color.secondaryText)
+            )
         )
     }
 

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -1,5 +1,6 @@
 package com.intersoft.groupup_app.navigation
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -181,7 +182,7 @@ fun EventDetailsPage(
 
                 hostId == AuthContext.id -> {
                     EventDetailsButton(buttonName = "Delete Event") {
-                        /*TODO Add delete event functionality*/
+                        EventManager.deleteEvent(eventId, {eventName = "SUCCESS"}, {eventName = "FAIL"})
                     }
                     Spacer(modifier = Modifier.height(20.dp))
                     EventDetailsButton(buttonName = "Edit Event") {

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,7 +47,8 @@ fun EventDetailsPage(
         durationInMillis: Long,
         maxNumberOfParticipants: Int,
         location: String,
-        hostId: Int,) -> Unit
+        hostId: Int,) -> Unit,
+    onEventDeleted: () -> Unit
 ){
     var eventName by remember {
         mutableStateOf("")
@@ -235,6 +235,7 @@ fun EventDetailsPage(
             onConfirmButton = {
                 EventManager.deleteEvent(eventId, {eventName = "SUCCESS"}, {eventName = it})
                 isShowingDeleteDialog = false
+                onEventDeleted()
             },
             onDismissButton = {
                 isShowingDeleteDialog = false

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -1,5 +1,6 @@
 package com.intersoft.groupup_app.navigation
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,6 +27,7 @@ import com.intersoft.auth.AuthContext
 import com.intersoft.event.EventManager
 import com.intersoft.ui.ConfirmationDialog
 import com.intersoft.ui.DisabledTextField
+import com.intersoft.ui.ErrorText
 import com.intersoft.ui.LabelText
 import com.intersoft.ui.LoadingScreen
 import com.intersoft.ui.ParticipantNumberDisplayField
@@ -107,6 +109,9 @@ fun EventDetailsPage(
     var durationInMillis : Long by remember{
         mutableLongStateOf(0)
     }
+    var errorText by remember{
+        mutableStateOf("")
+    }
 
      EventManager.getEvent(eventId ,{onGetEventFail()}){
 
@@ -174,6 +179,8 @@ fun EventDetailsPage(
             DisabledTextField(textvalue = host)
             Spacer(modifier = Modifier.height(20.dp))
 
+            ErrorText(text = errorText)
+            Spacer(modifier = Modifier.height(20.dp))
 
             when{
                 hostId != AuthContext.id &&
@@ -233,9 +240,8 @@ fun EventDetailsPage(
             title = "Deleting event",
             dialogText = "Are you sure you want to delete the event \"${eventName}\"?",
             onConfirmButton = {
-                EventManager.deleteEvent(eventId, {eventName = "SUCCESS"}, {eventName = it})
                 isShowingDeleteDialog = false
-                onEventDeleted()
+                EventManager.deleteEvent(eventId, {onEventDeleted()}, { errorText = it})
             },
             onDismissButton = {
                 isShowingDeleteDialog = false

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -1,6 +1,5 @@
 package com.intersoft.groupup_app.navigation
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
+++ b/frontend/app/src/main/java/com/intersoft/groupup_app/navigation/EventDetailsPage.kt
@@ -1,6 +1,5 @@
 package com.intersoft.groupup_app.navigation
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -112,35 +111,44 @@ fun EventDetailsPage(
     var errorText by remember{
         mutableStateOf("")
     }
+    var isDeleted by remember{
+        mutableStateOf(false)
+    }
 
-     EventManager.getEvent(eventId ,{onGetEventFail()}){
+    if(!isDeleted) {
+        EventManager.getEvent(eventId, { onGetEventFail() }) {
 
-         val totalMillis = it.date.toInstant().toEpochMilli() - 3600000 // subtract 1 hour because the epoch functions ads 1 hour to account for time offset, which does not make sense here
-         eventName = it.name
-         description = it.description
-         eventDate = DateTimeManager.formatMillisToDateTime(totalMillis)
-         selectedDateInMillis = totalMillis
-         durationInMillis = DateTimeManager.calculateMillisFromMinutes(eventDuration)
-         startTimeInMillis = DateTimeManager.calculateStartTimeFromString(DateTimeManager.formatMillisToDateTime(totalMillis))
-         eventDuration = it.duration
-         maxNumberOfParticipants = it.max_participants
-         hostId = it.owner_id
+            val totalMillis = it.date.toInstant()
+                .toEpochMilli() - 3600000 // subtract 1 hour because the epoch functions ads 1 hour to account for time offset, which does not make sense here
+            eventName = it.name
+            description = it.description
+            eventDate = DateTimeManager.formatMillisToDateTime(totalMillis)
+            selectedDateInMillis = totalMillis
+            durationInMillis = DateTimeManager.calculateMillisFromMinutes(eventDuration)
+            startTimeInMillis = DateTimeManager.calculateStartTimeFromString(
+                DateTimeManager.formatMillisToDateTime(totalMillis)
+            )
+            eventDuration = it.duration
+            maxNumberOfParticipants = it.max_participants
+            hostId = it.owner_id
 
-         val participantsNumber = it.participants?.count()
-         if(participantsNumber != null)
-            currentNumberOfParticipants = participantsNumber
-         location = it.location
-         EventManager.getHostname(
-             it.owner_id,
-             AuthContext.token!!,
-             onGetHostnameError = {},
-             onGetHostnameSuccess = {hostname -> host = hostname }
-         )
+            val participantsNumber = it.participants?.count()
+            if (participantsNumber != null)
+                currentNumberOfParticipants = participantsNumber
+            location = it.location
+            EventManager.getHostname(
+                it.owner_id,
+                AuthContext.token!!,
+                onGetHostnameError = {},
+                onGetHostnameSuccess = { hostname -> host = hostname }
+            )
 
-         isParticipant = it.participants!!.any{user -> user.username == AuthContext.username} &&
-                 it.owner_id != AuthContext.id
+            isParticipant =
+                it.participants!!.any { user -> user.username == AuthContext.username } &&
+                        it.owner_id != AuthContext.id
 
-         eventDataWasRecieved = true
+            eventDataWasRecieved = true
+        }
     }
 
     if(eventDataWasRecieved){
@@ -241,7 +249,13 @@ fun EventDetailsPage(
             dialogText = "Are you sure you want to delete the event \"${eventName}\"?",
             onConfirmButton = {
                 isShowingDeleteDialog = false
-                EventManager.deleteEvent(eventId, {onEventDeleted()}, { errorText = it})
+                EventManager.deleteEvent(
+                    eventId,
+                    {
+                        isDeleted = true
+                        onEventDeleted()
+                    },
+                    { errorText = it})
             },
             onDismissButton = {
                 isShowingDeleteDialog = false
@@ -254,7 +268,6 @@ fun EventDetailsPage(
             )
         )
     }
-
 }
 
 

--- a/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
+++ b/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Card
@@ -348,6 +349,7 @@ fun ConfirmationDialog(
     dialogText: String,
     onConfirmButton: () -> Unit,
     onDismissButton: () -> Unit,
+    confirmColors: ButtonColors = ButtonDefaults.buttonColors()
 ){
     AlertDialog(onDismissRequest = onDismissButton,
         title = {
@@ -357,7 +359,7 @@ fun ConfirmationDialog(
             Text(text = dialogText)
         },
         confirmButton = {
-            Button(onClick = onConfirmButton) {
+            Button(onClick = onConfirmButton, colors = confirmColors) {
                 Text(text = "Confirm")
             }
         },

--- a/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
+++ b/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
@@ -245,7 +245,7 @@ fun ErrorText(text: String){
     Text(
         text = text,
         color = colorResource(R.color.errorColor),
-        fontSize = 12.sp,
+        fontSize = 14.sp,
         textAlign = TextAlign.Center,
         modifier = Modifier.fillMaxWidth()
     )

--- a/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
+++ b/frontend/core/ui/src/main/java/com/intersoft/ui/SimpleComponents.kt
@@ -10,11 +10,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -25,7 +23,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,7 +38,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 

--- a/frontend/data/event/build.gradle.kts
+++ b/frontend/data/event/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.intersoft.event"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 27

--- a/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
+++ b/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
@@ -295,6 +295,14 @@ class EventRepository: IEventRepository {
             }
         )
     }
+
+    override fun deleteEvent(
+        eventId: Int,
+        onDeleteEventError: (String) -> Unit,
+        onDeleteEventSuccess: (String) -> Unit
+    ) {
+        NetworkManager.deleteEvent(eventId, onDeleteEventSuccess = onDeleteEventSuccess, onDeleteEventFail = onDeleteEventError)
+    }
 }
 
 

--- a/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
+++ b/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
@@ -301,7 +301,14 @@ class EventRepository: IEventRepository {
         onDeleteEventError: (String) -> Unit,
         onDeleteEventSuccess: (String) -> Unit
     ) {
-        NetworkManager.deleteEvent(eventId, onDeleteEventSuccess = onDeleteEventSuccess, onDeleteEventFail = onDeleteEventError)
+        NetworkManager.deleteEvent(eventId,
+            onDeleteEventSuccess = {onDeleteEventSuccess("Event has been deleted")},
+            onDeleteEventFail = {
+                if(it != null){
+                    onDeleteEventError(it)
+                }
+                else onDeleteEventError("Unknown server error")}
+        )
     }
 }
 

--- a/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
+++ b/frontend/data/event/src/main/java/com/intersoft/event/EventRepository.kt
@@ -307,7 +307,7 @@ class EventRepository: IEventRepository {
                 if(it != null){
                     onDeleteEventError(it)
                 }
-                else onDeleteEventError("Unknown server error")}
+                else onDeleteEventError("Unknown error occurred")}
         )
     }
 }

--- a/frontend/data/event/src/main/java/com/intersoft/event/IEventRepository.kt
+++ b/frontend/data/event/src/main/java/com/intersoft/event/IEventRepository.kt
@@ -25,4 +25,6 @@ interface IEventRepository {
 
     fun editEvent(eventId: Int,newEvent: EventModel,authToken: String ,onEditEventError: (String) -> Unit, onEditEventSuccess: (String) -> Unit){
     }
+
+    fun deleteEvent(eventId: Int, onDeleteEventError: (String) -> Unit, onDeleteEventSuccess: (String) -> Unit){}
 }

--- a/frontend/data/event/src/main/java/com/intersoft/event/MockEventRepository.kt
+++ b/frontend/data/event/src/main/java/com/intersoft/event/MockEventRepository.kt
@@ -43,4 +43,12 @@ class MockEventRepository : IEventRepository {
     ) {
         TODO("Not yet implemented")
     }
+
+    override fun deleteEvent(
+        eventId: Int,
+        onDeleteEventError: (String) -> Unit,
+        onDeleteEventSuccess: (String) -> Unit
+    ) {
+        eventList.removeIf { it.id == eventId }
+    }
 }

--- a/frontend/feature/event/build.gradle.kts
+++ b/frontend/feature/event/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(project(mapOf("path" to ":data:event")))
     implementation(project(mapOf("path" to ":core:ui")))
     implementation(project(mapOf("path" to ":data:user")))
+    implementation(project(":data:user"))
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/frontend/feature/event/src/main/java/com/intersoft/event/EventManager.kt
+++ b/frontend/feature/event/src/main/java/com/intersoft/event/EventManager.kt
@@ -124,6 +124,10 @@ object EventManager {
         )
     }
 
+    fun deleteEvent(eventId: Int, onDeleteSuccess: (String) -> Unit, onDeleteFail: (String) -> Unit){
+        eventRepository.deleteEvent(eventId, onDeleteEventSuccess = onDeleteSuccess, onDeleteEventError = onDeleteFail)
+    }
+
     data class RecievedEventData (
         val id : Int,
         val name: String,

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -91,8 +91,9 @@ object NetworkManager {
         res.enqueue(ResponseHandler<StoredEventData>(successCode = 200, errorCode = 404, onGetEventSuccess, onGetEventFail))
     }
 
-    fun deleteEvent(eventId: Int, onDeleteEventSuccess: (String) -> Unit, onDeleteEventFail: (String) -> Unit){
-
+    fun deleteEvent(eventId: Int, onDeleteEventSuccess: (Unit) -> Unit, onDeleteEventFail: (String?) -> Unit){
+        val res = serverService.deleteEvent(eventId)
+        res.enqueue(ResponseHandler<Unit>(successCode = 204, errorCode = 404, onDeleteEventSuccess, onDeleteEventFail))
     }
 
     fun getUser(userId: Int, authToken: String, onGetUserSuccess: (UserData) -> Unit, onGetUserError: (String?) -> Unit) {

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -30,11 +30,10 @@ object NetworkManager {
     fun registerUser(user: RegisterBody, requestListener: RequestListener){
 
         val res = serverService.createUser(user)
-        Log.d("NetworkManager", "Request ${res.request().body()}")
 
         res.enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                Log.d("NetworkManager", "Response: ${response?.body()}")
+                Log.d("NetworkManager", "Response: ${response.body()}")
                 if(response?.code() != 201){
                     if(response?.code() == 422)
                         requestListener.onError(response.errorBody()?.string())
@@ -42,8 +41,8 @@ object NetworkManager {
                 } else requestListener.onSuccess(response.body()!!)
             }
 
-            override fun onFailure(call: Call<ResponseBody>?, t: Throwable?) {
-                Log.d("NetworkManager", "Error: ${t?.message}")
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                Log.d("NetworkManager", "Error: ${t.message}")
                 requestListener.onError("Broken connection")
             }
         })
@@ -142,28 +141,23 @@ object NetworkManager {
                                   val onFail: (String?) -> Unit): Callback<T>{
 
         override fun onResponse(call: Call<T>, response: Response<T>) {
-            Log.d("NetworkManager", "Response: ${response?.message()}")
-            if (response != null) {
-                if (response.code() != successCode) {
-
-                    if (response.code() == errorCode) {
-                        val errorMessage = response.errorBody()?.string()
-                        Log.d("NetworkManager", "Error: $errorMessage")
-                        onFail(errorMessage)
-                    }
-                    else onFail("Unknown error occurred")
-                } else {
-                    Log.d("NetworkManager", "Success: ${response.body()}")
-                    if(response.body() == null) onFail("no response from server")
-                    else onSuccess(response.body()!!)
+            Log.d("NetworkManager", "Response: ${response.message()}")
+            if (response.code() != successCode) {
+                if (response.code() == errorCode) {
+                    val errorMessage = response.errorBody()?.string()
+                    Log.d("NetworkManager", "Error: $errorMessage")
+                    onFail(errorMessage)
                 }
-
-
+                else onFail("Unknown error occurred")
+            } else {
+                Log.d("NetworkManager", "Success: ${response.body()}")
+                if (response.body() == null) onFail("no response from server")
+                else onSuccess(response.body()!!)
             }
         }
 
-        override fun onFailure(call: Call<T>?, t: Throwable?) {
-            Log.d("NetworkManager", "Error: ${t?.message}")
+        override fun onFailure(call: Call<T>, t: Throwable) {
+            Log.d("NetworkManager", "Error: ${t.message}")
             onFail("Could not reach server")
         }
 

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -90,29 +90,9 @@ object NetworkManager {
         res.enqueue(ResponseHandler<StoredEventData>(successCode = 200, errorCode = 404, onGetEventSuccess, onGetEventFail))
     }
 
-    fun deleteEvent(eventId: Int, onDeleteEventSuccess: () -> Unit, onDeleteEventFail: (String?) -> Unit){
+    fun deleteEvent(eventId: Int, onDeleteEventSuccess: (Unit) -> Unit, onDeleteEventFail: (String?) -> Unit){
         val res = serverService.deleteEvent(eventId)
-        res.enqueue(object: Callback<Unit>{
-            override fun onResponse(call: Call<Unit>, response: Response<Unit>) {
-                Log.d("NetworkManager", "Response: ${response.message()}")
-                if (response.code() != 204) {
-                    if (response.code() == 404) {
-                        val errorMessage = response.errorBody()?.string()
-                        Log.d("NetworkManager", "Error: $errorMessage")
-                        onDeleteEventFail(errorMessage)
-                    }
-                    else onDeleteEventFail("Unknown error occurred")
-                } else {
-                    Log.d("NetworkManager", "Success: ${response.body()}")
-                    onDeleteEventSuccess()
-                }
-            }
-
-            override fun onFailure(call: Call<Unit>, t: Throwable) {
-                Log.d("NetworkManager", "Error: ${t.message}")
-                onDeleteEventFail("Could not reach server")
-            }
-        })
+        res.enqueue(ResponseHandler<Unit>(successCode = 204, errorCode = 404, onDeleteEventSuccess, onDeleteEventFail))
     }
 
     fun getUser(userId: Int, authToken: String, onGetUserSuccess: (UserData) -> Unit, onGetUserError: (String?) -> Unit) {

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -34,8 +34,8 @@ object NetworkManager {
         res.enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
                 Log.d("NetworkManager", "Response: ${response.body()}")
-                if(response?.code() != 201){
-                    if(response?.code() == 422)
+                if(response.code() != 201){
+                    if(response.code() == 422)
                         requestListener.onError(response.errorBody()?.string())
                     else requestListener.onError("Unknown error occurred")
                 } else requestListener.onSuccess(response.body()!!)

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -91,6 +91,10 @@ object NetworkManager {
         res.enqueue(ResponseHandler<StoredEventData>(successCode = 200, errorCode = 404, onGetEventSuccess, onGetEventFail))
     }
 
+    fun deleteEvent(eventId: Int, onDeleteEventSuccess: (String) -> Unit, onDeleteEventFail: (String) -> Unit){
+
+    }
+
     fun getUser(userId: Int, authToken: String, onGetUserSuccess: (UserData) -> Unit, onGetUserError: (String?) -> Unit) {
         val res = serverService.getUser(userId, authToken)
         res.enqueue(ResponseHandler<UserData>(successCode = 200, errorCode = 401, onGetUserSuccess,onGetUserError))

--- a/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/NetworkManager.kt
@@ -90,9 +90,29 @@ object NetworkManager {
         res.enqueue(ResponseHandler<StoredEventData>(successCode = 200, errorCode = 404, onGetEventSuccess, onGetEventFail))
     }
 
-    fun deleteEvent(eventId: Int, onDeleteEventSuccess: (Unit) -> Unit, onDeleteEventFail: (String?) -> Unit){
+    fun deleteEvent(eventId: Int, onDeleteEventSuccess: () -> Unit, onDeleteEventFail: (String?) -> Unit){
         val res = serverService.deleteEvent(eventId)
-        res.enqueue(ResponseHandler<Unit>(successCode = 204, errorCode = 404, onDeleteEventSuccess, onDeleteEventFail))
+        res.enqueue(object: Callback<Unit>{
+            override fun onResponse(call: Call<Unit>, response: Response<Unit>) {
+                Log.d("NetworkManager", "Response: ${response.message()}")
+                if (response.code() != 204) {
+                    if (response.code() == 404) {
+                        val errorMessage = response.errorBody()?.string()
+                        Log.d("NetworkManager", "Error: $errorMessage")
+                        onDeleteEventFail(errorMessage)
+                    }
+                    else onDeleteEventFail("Unknown error occurred")
+                } else {
+                    Log.d("NetworkManager", "Success: ${response.body()}")
+                    onDeleteEventSuccess()
+                }
+            }
+
+            override fun onFailure(call: Call<Unit>, t: Throwable) {
+                Log.d("NetworkManager", "Error: ${t.message}")
+                onDeleteEventFail("Could not reach server")
+            }
+        })
     }
 
     fun getUser(userId: Int, authToken: String, onGetUserSuccess: (UserData) -> Unit, onGetUserError: (String?) -> Unit) {

--- a/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
@@ -14,6 +14,7 @@ import com.intersoft.network.models.responses.UserData
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
@@ -69,5 +70,10 @@ interface ServerService {
     fun editEvent(
         @Path("event_id") id: Int,
         @Body event: EditEventBody,
+        @Header("Authorization") authToken: String ) : Call<EventDetails>
+
+    @DELETE("/api/v1/events/{event_id}")
+    fun deleteEvent(
+        @Path("event_id") id: Int,
         @Header("Authorization") authToken: String ) : Call<EventDetails>
 }

--- a/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
@@ -74,7 +74,5 @@ interface ServerService {
 
     @DELETE("/api/v1/events/{event_id}")
     fun deleteEvent(
-        @Path("event_id") id: Int,
-    //    @Header("Authorization") authToken: String
-    ) : Call<Unit>
+        @Path("event_id") id: Int) : Call<Unit>
 }

--- a/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
+++ b/frontend/network/src/main/java/com/intersoft/network/ServerService.kt
@@ -75,5 +75,6 @@ interface ServerService {
     @DELETE("/api/v1/events/{event_id}")
     fun deleteEvent(
         @Path("event_id") id: Int,
-        @Header("Authorization") authToken: String ) : Call<EventDetails>
+    //    @Header("Authorization") authToken: String
+    ) : Call<Unit>
 }


### PR DESCRIPTION
This PR closes [IAP-63](https://airvjezbe-g4.atlassian.net/browse/IAP-63).

![image](https://github.com/DMindek/GroupUP/assets/100624088/2492f967-5b8a-4057-ae88-9aaa2bbc73a9)

Currently the code in NetworkManager has a lot of code that is only required because the server returns an empty response on a successful deletion. This code can be removed at a later date when the backend is changed to return a simple success message in its response (eg. "successfuly deleted event").